### PR TITLE
Fix GPS pins and solve when an SSID length is too large for WiFi.hostByName() to handle

### DIFF
--- a/src/Demo/Scan.h
+++ b/src/Demo/Scan.h
@@ -303,9 +303,13 @@ void makeDNSRequest() {
             return;
         }
 
+        //check for success before reporting success
+        if (dnsRequestSuccess) {
         Serial.println("[+][DNS] Success making request!");
-        reqs++;
         drawMockup(currentGPS,currTime,sats,nets,reqs,opn,"DNS SUCCESS");
+        }
+        
+        reqs++;
     }
 }
 

--- a/src/Demo/Scan.h
+++ b/src/Demo/Scan.h
@@ -1,5 +1,5 @@
-#define GPSRX D3
-#define GPSTX D4
+#define GPSRX D4
+#define GPSTX D3
 
 #include "Vars.h"
 #include "Base32.h"


### PR DESCRIPTION
1) fix the GPS pins being inverted
2) fix the condition when an SSID appended to the end of the GPS coordinates causes the DNS request to fail by providing a subdomain that is too large for WiFi.hostByName() to handle by removing the SSID from the encoded string after 2 failed DNS attempts.